### PR TITLE
修改 MySql没有字段类型 money，反向工程需要映射到 decimal

### DIFF
--- a/XCode/DataAccessLayer/Database/MySql.cs
+++ b/XCode/DataAccessLayer/Database/MySql.cs
@@ -351,6 +351,8 @@ namespace XCode.DataAccessLayer
         {
             // MySql没有ntext，映射到text
             if (typeName.EqualIgnoreCase("ntext")) typeName = "text";
+            //2017-08-19 siery修改 MySql没有money，映射到decimal
+            if (typeName.EqualIgnoreCase("money")) typeName = "decimal";
             //field.Table.DbType == DatabaseType.MySql
             if (field.DataType == typeof(String) && field.Length == -1)
             {


### PR DESCRIPTION
使用MySql 数据库，xml 配置脚本配置字段类型为 decimal时候， xcoder 生成实体会指定属性字段类型为money 。出现的问题导致反向工程时MySql 的创建表语句会标识字段为 money 报错。本次修改 MySql没有字段类型 money，反向工程需要映射到 decimal。