### PR TITLE
修复HttpHelper AddHeaders 方法 重复添加请求头，添加了去重判断

### DIFF
--- a/NewLife.Core/Http/HttpHelper.cs
+++ b/NewLife.Core/Http/HttpHelper.cs
@@ -323,6 +323,9 @@ namespace NewLife.Http
 
             foreach (var item in headers)
             {
+                //判断请求头中是否已存在，存在先删除，再添加
+                if (client.DefaultRequestHeaders.Contains(item.Key))
+                    client.DefaultRequestHeaders.Remove(item.Key);
                 client.DefaultRequestHeaders.Add(item.Key, item.Value);
             }
 


### PR DESCRIPTION
//判断请求头中是否已存在，存在先删除，再添加
  if (client.DefaultRequestHeaders.Contains(item.Key))
      client.DefaultRequestHeaders.Remove(item.Key);