### PR TITLE
增加 \n以及\r的截断处理， 处理类似如下json字符串的转换错误：==>{"key":"http://*:5000" \n /*注释*…

### DIFF
--- a/NewLife.Core/Configuration/JsonConfigProvider.cs
+++ b/NewLife.Core/Configuration/JsonConfigProvider.cs
@@ -161,8 +161,8 @@ namespace NewLife.Configuration
         /// <param name="text"></param>
         /// <returns></returns>
         public static String TrimComment(String text)
-        {
-            var lines = text.Split(Environment.NewLine);
+        {            
+            var lines = text.Split(Environment.NewLine,"\n","\r");//增加 \r以及\n的处理， 处理类似如下json转换时的错误：==>{"key":"http://*:5000" \n /*注释*/}<==
             text = lines
                 .Where(e => !e.IsNullOrEmpty() && !e.TrimStart().StartsWith("//"))
                 // 没考虑到链接中带双斜杠的，以下导致链接的内容被干掉


### PR DESCRIPTION
增加 \n以及\r的截断处理， 处理类似如下json字符串的转换错误：==>{"key":"http://*:5000" \n /*注释*…